### PR TITLE
Fixes stopped indicator when performing stop or continue.

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -899,20 +899,19 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            response.body = {
+                allThreadsContinued: false,
+            }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendRunCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        response.body = {
-            allThreadsContinued: false,
-        }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 
@@ -921,17 +920,16 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendStepOverCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 
@@ -943,17 +941,16 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendStepIntoCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 
@@ -965,17 +962,16 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendStepOutCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 


### PR DESCRIPTION
When the IDE requests a continue operation (step in, out, over, continue) it expects a Response and will remove the current execution position. With XDebug/DBGp the TCP connection will not send a response until another stop condition is encountered this may take an arbitrary amount of time.
This change fixes this by doing some basic validation (is the threadId valid) and then sends a response before executing the continuation command.

Closes #358