### PR TITLE
Removes code execution indicator when process is terminated.

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -270,6 +270,7 @@ class PhpDebugSession extends vscode.DebugSession {
                                         )
                                     )
                                 }
+                                this.sendEvent(new vscode.ContinuedEvent(connection.id, false))
                                 this.sendEvent(new vscode.ThreadEvent('exited', connection.id))
                                 connection.close()
                                 this._connections.delete(connection.id)


### PR DESCRIPTION
If the debugger is standing on a line and DBGp connection is interrupted (for example, php process terminated) the thread will go away, but the execution indicator will stay. Signaling a continued event before Thread exit solves this.